### PR TITLE
Correct "it's" to "its" in command doc comments

### DIFF
--- a/src/glimr/internal/console/commands/make_action.gleam
+++ b/src/glimr/internal/console/commands/make_action.gleam
@@ -6,7 +6,7 @@ import glimr/filesystem/filesystem
 /// The console command description.
 const description = "Create a new action"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()

--- a/src/glimr/internal/console/commands/make_command.gleam
+++ b/src/glimr/internal/console/commands/make_command.gleam
@@ -6,7 +6,7 @@ import glimr/filesystem/filesystem
 /// The console command description.
 const description = "Create a new command"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()

--- a/src/glimr/internal/console/commands/make_controller.gleam
+++ b/src/glimr/internal/console/commands/make_controller.gleam
@@ -6,7 +6,7 @@ import glimr/filesystem/filesystem
 /// The console command description.
 const description = "Create a new controller"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()

--- a/src/glimr/internal/console/commands/make_middleware.gleam
+++ b/src/glimr/internal/console/commands/make_middleware.gleam
@@ -6,7 +6,7 @@ import glimr/filesystem/filesystem
 /// The console command description.
 const description = "Create a new HTTP middleware"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()

--- a/src/glimr/internal/console/commands/make_model.gleam
+++ b/src/glimr/internal/console/commands/make_model.gleam
@@ -8,7 +8,7 @@ import glimr/utils/string as glimr_string
 /// The console command description.
 const description = "Create a new model"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()

--- a/src/glimr/internal/console/commands/make_route_file.gleam
+++ b/src/glimr/internal/console/commands/make_route_file.gleam
@@ -6,7 +6,7 @@ import glimr/filesystem/filesystem
 /// The console command description.
 const description = "Create a new route file"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()

--- a/src/glimr/internal/console/commands/make_rule.gleam
+++ b/src/glimr/internal/console/commands/make_rule.gleam
@@ -6,7 +6,7 @@ import glimr/filesystem/filesystem
 /// The console command description.
 const description = "Create a new validation rule"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()

--- a/src/glimr/internal/console/commands/make_validator.gleam
+++ b/src/glimr/internal/console/commands/make_validator.gleam
@@ -6,7 +6,7 @@ import glimr/filesystem/filesystem
 /// The console command description.
 const description = "Create a new form validator"
 
-/// Define the Command and it's properties.
+/// Define the Command and its properties.
 ///
 pub fn command() -> Command {
   command.new()


### PR DESCRIPTION
## Summary      

  - Fix possessive "it's" → "its" in doc comments across 7 make command files